### PR TITLE
Add channel and distance to event params

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,16 @@ A connection request.
 - `listenerId` - The `id` field of the listener that received this request.
 - `request` - The request to pass on to the `accept` method.
 - `side` - Which modem the request was received through.
-- `channel` - The channel the request was sent on.
-- `distance` - Distance of the sender.
+- `channel` - The channel the request was received on.
+- `distance` - Distance to the sender of the underlying modem message. This may not match the true originator for relayed messages.
 
 ### `"ecnet2_message", connectionId: string, sender: string, message: any`
 A message in a connection.
 - `connectionId` - The `id` field of the connection that received this message.
 - `sender` - The sender's address.
 - `message` - The deserialized message data.
-- `channel` - The channel the message was sent on.
-- `distance` - Distance of the sender.
+- `channel` - The channel the message was received on.
+- `distance` - Distance to the sender of the underlying modem message. This may not match the true originator for relayed messages.
 
 # Technical Details
 

--- a/README.md
+++ b/README.md
@@ -95,12 +95,16 @@ A connection request.
 - `listenerId` - The `id` field of the listener that received this request.
 - `request` - The request to pass on to the `accept` method.
 - `side` - Which modem the request was received through.
+- `channel` - The channel the request was sent on.
+- `distance` - Distance of the sender.
 
 ### `"ecnet2_message", connectionId: string, sender: string, message: any`
 A message in a connection.
 - `connectionId` - The `id` field of the connection that received this message.
 - `sender` - The sender's address.
 - `message` - The deserialized message data.
+- `channel` - The channel the message was sent on.
+- `distance` - Distance of the sender.
 
 # Technical Details
 

--- a/ecnet2/Connection.lua
+++ b/ecnet2/Connection.lua
@@ -20,7 +20,7 @@ function Connection:initialise(state, protocol, side)
     self.id = uid()
     self._protocol = protocol
     self._side = side
-    self._handler = function(m, _) return self:_handle(m, _) end
+    self._handler = function(m, _, c, d) return self:_handle(m, _, c, d) end
     self._state = state
     if state.d then ecnetd.handlers[state.d] = self._handler end
 end
@@ -35,7 +35,9 @@ end
 --- Handles an incoming packet, modifying the state.
 --- @param packet string
 --- @param _ string
-function Connection:_handle(packet, _)
+--- @param ch integer
+--- @param dist number
+function Connection:_handle(packet, _, ch, dist)
     local newState, msg = self._state.resolve(packet)
     self:_setState(newState)
     if not msg then return end
@@ -43,7 +45,7 @@ function Connection:_handle(packet, _)
     local ok, message = pcall(deserialize, msg)
     if ok then
         local addr = addressEncoder.encode(self._state.pk)
-        os.queueEvent("ecnet2_message", self.id, addr, message)
+        os.queueEvent("ecnet2_message", self.id, addr, message, ch, dist)
     end
 end
 

--- a/ecnet2/Listener.lua
+++ b/ecnet2/Listener.lua
@@ -21,7 +21,7 @@ function Listener:initialise(protocol)
     self._psk = blake3.digest(protocol._identity._pk .. protocol._hash)
     self._protocol = protocol
     self._processed = setmetatable({}, { __mode = "v" })
-    self._handler = function(m, s) return self:_handle(m, s) end
+    self._handler = function(m, s, c, d) return self:_handle(m, s, c, d) end
     local descriptor = blake3.digest(self._psk)
     ecnetd.handlers[descriptor] = self._handler
 end
@@ -29,9 +29,11 @@ end
 --- Handles an incoming packet.
 --- @param packet string
 --- @param side string
-function Listener:_handle(packet, side)
+--- @param ch integer
+--- @param dist number
+function Listener:_handle(packet, side, ch, dist)
     local request = { _lid = self.id, _nid = side, _packet = packet }
-    os.queueEvent("ecnet2_request", self.id, request, side)
+    os.queueEvent("ecnet2_request", self.id, request, side, ch, dist)
 end
 
 --- Accepts a request and builds a connection. Waits for the next request if

--- a/ecnet2/ecnetd.lua
+++ b/ecnet2/ecnetd.lua
@@ -7,7 +7,7 @@ local constants = require "ecnet2.constants"
 local state
 
 --- @param message string
-local function enqueue(message, side)
+local function enqueue(message, side, ch, dist)
     if type(message) ~= "string" then return end
     if #message >= 2 ^ 16 then return end
     if #message < 32 then return end
@@ -20,8 +20,8 @@ end
 local function ecnetd()
     while not state do coroutine.yield() end
     while true do
-        local _, side, ch, _, msg = coroutine.yield("modem_message")
-        if ch == constants.CHANNEL then enqueue(msg, side) end
+        local _, side, ch, _, msg, dist = coroutine.yield("modem_message")
+        if ch == constants.CHANNEL then enqueue(msg, side, ch, dist) end
     end
 end
 

--- a/examples/ping/server.lua
+++ b/examples/ping/server.lua
@@ -30,12 +30,13 @@ local listener = ping:listen()
 local connections = {}
 
 while true do
-    local event, id, p2, p3 = os.pullEvent()
+    local event, id, p2, p3, ch, dist = os.pullEvent()
     if event == "ecnet2_request" and id == listener.id then
         -- Accept the request and send a greeting message.
         local connection = listener:accept("ping v1.0", p2)
         connections[connection.id] = connection
     elseif event == "ecnet2_message" and connections[id] then
+        print("got", p3, "on channel", ch, "from", dist, "blocks away")
         -- Reply with the same message.
         connections[id]:send(p3)
     end


### PR DESCRIPTION
Allows users to get the distance and channel the message was sent from. The distance is obviously useful, the channel is more for future-proofing the potential world where the channel is allowed to be changed from the default.