### PR TITLE
Remove redrun requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ examples in the examples directory.
 ## Dependencies
 - [CCryptolib](https://github.com/migeyel/ccryptolib) >=1.1.0 (you still need to
   initialize the random generator yourself)
-- [RedRun](https://gist.github.com/MCJack123/473475f07b980d57dd2bd818026c97e8)
 
 ## Goals
 - Let the user manage the lifetime of connections.
@@ -32,6 +31,10 @@ Returns whether a modem is open for communications.
 
 ### `ecnet2.address(): string`
 Returns the address for connecting to this device.
+
+### `ecnet2.daemon`
+Function used for managing listener and connection events.
+Intended to be put in parallel with users code.
 
 ### `ecnet2.Protocol(interface: IProtocol): Protocol`
 Creates a protocol from a given interface.

--- a/ecnet2/Connection.lua
+++ b/ecnet2/Connection.lua
@@ -22,13 +22,13 @@ function Connection:initialise(state, protocol, side)
     self._side = side
     self._handler = function(m, _) return self:_handle(m, _) end
     self._state = state
-    if state.d then ecnetd.handlers[state.d] = self._handler end
+    if state.d then ecnetd.addHandler(state.d, self._handler) end
 end
 
 --- @param newState ecnet2.HandshakeState
 function Connection:_setState(newState)
-    if self._state.d then ecnetd.handlers[self._state.d] = nil end
-    if newState.d then ecnetd.handlers[newState.d] = self._handler end
+    if self._state.d then ecnetd.removeHandler(self._state.d) end
+    if newState.d then ecnetd.addHandler(newState.d, self._handler) end
     self._state = newState
 end
 

--- a/ecnet2/Listener.lua
+++ b/ecnet2/Listener.lua
@@ -23,7 +23,7 @@ function Listener:initialise(protocol)
     self._processed = setmetatable({}, { __mode = "v" })
     self._handler = function(m, s) return self:_handle(m, s) end
     local descriptor = blake3.digest(self._psk)
-    ecnetd.handlers[descriptor] = self._handler
+    ecnetd.addHandler(descriptor, self._handler)
 end
 
 --- Handles an incoming packet.

--- a/ecnet2/ecnetd.lua
+++ b/ecnet2/ecnetd.lua
@@ -2,7 +2,7 @@ local constants = require "ecnet2.constants"
 
 --- The global daemon state.
 
-local handlers = {}
+local handlers = setmetatable({}, { __mode = "v" })
 
 --- @param message string
 local function enqueue(message, side)
@@ -23,7 +23,6 @@ local function daemon()
 end
 
 local function addHandler(name, fun)
-    assert(not handlers[name], "Handler collision: " .. name)
     handlers[name] = fun
 end
 

--- a/ecnet2/init.lua
+++ b/ecnet2/init.lua
@@ -2,6 +2,7 @@ local constants = require "ecnet2.constants"
 local Identity = require "ecnet2.Identity"
 local modems = require "ecnet2.modems"
 local Protocol = require "ecnet2.Protocol"
+local ecnetd = require "ecnet2.ecnetd"
 
 local module = {}
 
@@ -22,6 +23,8 @@ end
 module.open = modems.open
 module.close = modems.close
 module.isOpen = modems.isOpen
+
+module.daemon = ecnetd.daemon
 
 --- Creates a protocol from a given interface.
 --- @param interface ecnet2.IProtocol A table describing the protocol.

--- a/examples/ping/client.lua
+++ b/examples/ping/client.lua
@@ -1,6 +1,7 @@
 local ecnet2 = require "ecnet2"
 local random = require "ccryptolib.random"
 
+-- https://www.random.org/strings/?num=1&len=32&digits=on&upperalpha=on&loweralpha=on&unique=on&format=plain&rnd=new
 -- Initialize the random generator.
 local postHandle = assert(http.post("https://krist.dev/ws/start", "{}"))
 local data = textutils.unserializeJSON(postHandle.readAll())
@@ -23,16 +24,20 @@ local ping = ecnet2.Protocol {
 }
 
 -- The server's address.
-local server = "OWLYs4X14N2brkhiZMHAScqjEydM27DOVLmLu3jmbhg="
+local server = "AZ2cVrQTGDLLRodwHFS3RoNYQOW0O_iCctVWxc9IrXQ="
 
--- Connect to the server.
-local connection = ping:connect(server, "top")
+local function main()
+    -- Connect to the server.
+    local connection = ping:connect(server, "top")
 
--- Wait for the greeting.
-print(select(2, connection:receive()))
-
--- Read inputs and print ping outputs.
-while true do
-    connection:send(read())
+    -- Wait for the greeting.
     print(select(2, connection:receive()))
+
+    -- Read inputs and print ping outputs.
+    while true do
+        connection:send(read())
+        print(select(2, connection:receive()))
+    end
 end
+
+parallel.waitForAny(main, ecnet2.daemon)

--- a/examples/ping/server.lua
+++ b/examples/ping/server.lua
@@ -29,14 +29,19 @@ local listener = ping:listen()
 -- For simplicity, we don't drop inactive connections.
 local connections = {}
 
-while true do
-    local event, id, p2, p3 = os.pullEvent()
-    if event == "ecnet2_request" and id == listener.id then
-        -- Accept the request and send a greeting message.
-        local connection = listener:accept("ping v1.0", p2)
-        connections[connection.id] = connection
-    elseif event == "ecnet2_message" and connections[id] then
-        -- Reply with the same message.
-        connections[id]:send(p3)
+local function main()
+    while true do
+        local event, id, p2, p3 = os.pullEvent()
+        if event == "ecnet2_request" and id == listener.id then
+            -- Accept the request and send a greeting message.
+            local connection = listener:accept("ping v1.0", p2)
+            connections[connection.id] = connection
+        elseif event == "ecnet2_message" and connections[id] then
+            -- Reply with the same message.
+            print("got: "..p3)
+            connections[id]:send(p3)
+        end
     end
 end
+
+parallel.waitForAny(main, ecnet2.daemon)


### PR DESCRIPTION
I wasn't planning on making this into a PR, but I'll give it a shot. 
1. Renames the `ecnetd.ecnetd` function to `ecnetd.daemon`
2. Passes it out of `init` as `ecnet2.daemon`
3. Removes all the redrun stuff
4. Replaces all mentions of `handler` to two functions that add or remove handler functions, checking to make sure no key collisions occur.

This puts the onus of running the daemon on the program that uses ecnet. I think this is a fair responsibility, APIs like Radon's krist API, [Krypton](https://github.com/Allymonies/Krypton/blob/main/init.lua#L172) does this, [Shatter](https://github.com/hugeblank/Shatter/blob/master/shatter.lua#L396) also does this for cursor handling. I don't believe accounting for global state should ever be the responsibility of an API.